### PR TITLE
Change revision downgrade number

### DIFF
--- a/server/alembic/versions/a982f043a300_add_is_deleted_column.py
+++ b/server/alembic/versions/a982f043a300_add_is_deleted_column.py
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = 'a982f043a300'
-down_revision: Union[str, None] = 'cbd8239ae1b7'
+down_revision: Union[str, None] = '754403255064'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
- [x] Tested on local & docker
- [ ] Documentation Updated
- [ ] Attached required context / screenshot

Two revisions were merged consecutively but both had migrations pointing to the latest one. After the first was merged, the revision should have been upgraded in the second one 