### PR TITLE
Fix Null Check in plan.py

### DIFF
--- a/server/plan.py
+++ b/server/plan.py
@@ -344,7 +344,7 @@ To help integration test the flow above:
     async def generate_test_plan_for_endpoint(
         self, identifier: str, project_details: list, preferences: dict = None 
     ):  
-        if preferences is None:
+        if not preferences:
             preferences = json.loads(EndpointManager(project_details[1]).get_preferences(identifier, project_details[2]))
         
         if preferences:


### PR DESCRIPTION
Instead of checking If preferences is none to check if it's empty, we use if not preferences.

- [ ] Tested on local & docker
- [ ] Documentation Updated
- [ ] Attached required context / screenshot